### PR TITLE
Update group_norm.py for TensorFlow/Keras compatibility

### DIFF
--- a/group_norm.py
+++ b/group_norm.py
@@ -1,4 +1,5 @@
-from keras.engine import Layer, InputSpec
+from keras.layers import Layer
+from keras.layers import InputSpec
 from keras import initializers
 from keras import regularizers
 from keras import constraints

--- a/group_norm.py
+++ b/group_norm.py
@@ -5,7 +5,7 @@ from keras import regularizers
 from keras import constraints
 from keras import backend as K
 
-from keras.utils.generic_utils import get_custom_objects
+from keras.utils import get_custom_objects
 
 
 class GroupNormalization(Layer):


### PR DESCRIPTION

Updated the import statements in group_norm.py to ensure compatibility with the latest versions of TensorFlow/Keras.
Adjusted the references to get_custom_objects, Layer, and InputSpec to reflect their new locations in recent updates.
Reason for Changes
These changes are intended to maintain the functionality of the codebase with the most current versions of TensorFlow/Keras. I hope this helps keep the project up to date and running smoothly.

Thank you for considering this contribution!